### PR TITLE
use card instead of chips

### DIFF
--- a/views/homepage/components/ChattingComponent.vue
+++ b/views/homepage/components/ChattingComponent.vue
@@ -1,6 +1,6 @@
 (%define "chattingComponent"%)
 <template>
-  <v-container fluid>
+  <v-container style="height: 80vh; " fluid>
     <v-row no-gutters>
       <v-col cols="12">
         <v-row no-gutters>
@@ -27,40 +27,63 @@
         <v-col cols="12"></v-col>
       </v-col>
 
-      <v-flex style="max-height: 680px; " class="overflow-auto">
+      <v-container fluid style="height: 80vh; " class="overflow-auto">
         <v-row>
           <v-col cols="12" align="right">
-            <v-chip class="ma-2">Hello</v-chip>
+            <v-card outlined class="d-inline-block mx-auto">
+              <v-card-title class="text--secondary">
+                <h6>11:44PM 12/04/2020</h6>
+                <v-spacer></v-spacer>
+                <v-card-actions>
+                  <v-menu absolute bottom left>
+                    <template v-slot:activator="{ on }">
+                      <v-btn icon v-on="on">
+                        <v-icon>mdi-chevron-down</v-icon>
+                      </v-btn>
+                    </template>
+
+                    <v-list>
+                      <v-list-item v-for="i in 5" :key="i">
+                        <v-list-item-title>{{i}}</v-list-item-title>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                </v-card-actions>
+              </v-card-title>
+              <v-card-text class="flex">
+                <span>Hello there my name is michael</span>
+              </v-card-text>
+            </v-card>
           </v-col>
+
           <v-col cols="12" align="left">
-            <v-chip class="ma-2">typing....</v-chip>
-          </v-col>
-          <v-col cols="12" align="right">
-            <v-chip class="ma-2">Hello</v-chip>
-          </v-col>
-          <v-col cols="12" align="left">
-            <v-chip class="ma-2">typing....</v-chip>
-          </v-col>
-          <v-col cols="12" align="right">
-            <v-chip class="ma-2">Hello</v-chip>
-          </v-col>
-          <v-col cols="12" align="left">
-            <v-chip class="ma-2">typing....</v-chip>
-          </v-col>
-          <v-col cols="12" align="right">
-            <v-chip class="ma-2">Hello</v-chip>
-          </v-col>
-          <v-col cols="12" align="left">
-            <v-chip class="ma-2">typing....</v-chip>
-          </v-col>
-          <v-col cols="12" align="right">
-            <v-chip class="ma-2">Hello</v-chip>
-          </v-col>
-          <v-col cols="12" align="left">
-            <v-chip class="ma-2">typing....</v-chip>
+            <v-card outlined class="d-inline-block mx-auto">
+              <v-card-title class="text--secondary">
+                <h6>Matric 11:44PM 12/04/2020</h6>
+                <v-spacer></v-spacer>
+                <v-card-actions>
+                  <v-menu absolute bottom left>
+                    <template v-slot:activator="{ on }">
+                      <v-btn icon v-on="on">
+                        <v-icon>mdi-chevron-down</v-icon>
+                      </v-btn>
+                    </template>
+
+                    <v-list>
+                      <v-list-item v-for="i in 5" :key="i">
+                        <v-list-item-title>{{i}}</v-list-item-title>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                </v-card-actions>
+              </v-card-title>
+              <v-card-text class="flex">
+                <span>Hi there</span>
+              </v-card-text>
+            </v-card>
           </v-col>
         </v-row>
-      </v-flex>
+      </v-container>
 
       <v-row no-gutters>
         <v-btn fab outline flat depressed>

--- a/views/homepage/components/SideBar.vue
+++ b/views/homepage/components/SideBar.vue
@@ -25,7 +25,7 @@
       <v-col cols="12"></v-col>
     </v-row>
 
-    <v-flex fluid style="max-height: 490px; max-width: 300px" class="overflow-y-auto">
+    <v-flex fluid style="height: 55vh; max-width: 300px" class="overflow-y-auto">
       <v-row no-gutters>
         <v-list tile dense three-line>
           <v-list-item-group v-model="item" color="black">


### PR DESCRIPTION
closes #13 
This uses card to show user text and add feature like name, time of chat and dropdown functionality.
> Former
![image](https://user-images.githubusercontent.com/31141573/77238828-27037c00-6bd4-11ea-886e-1823281d3921.png)

> New
<img width="1675" alt="Screenshot 2020-03-22 at 00 30 00" src="https://user-images.githubusercontent.com/31141573/77238842-47333b00-6bd4-11ea-8c66-cbfa66b280af.png">

